### PR TITLE
Add utilities plugin with load-claude-docs skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for agent plugins including skills, commands, and tools for software engineering and product development",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
@@ -32,6 +32,12 @@
         "./agents/code-reviewer.md",
         "./agents/retro-agent.md"
       ]
+    },
+    {
+      "name": "utilities",
+      "description": "General-purpose utility skills including Claude Code documentation loading",
+      "source": "./plugins/utilities",
+      "strict": false
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ End-to-end development workflow orchestration. Runs a complete plan â†’ review â
 - **code-reviewer** - Reviews PR against original plan (fresh context)
 - **retro-agent** - Files retrospective issue in marketplace (autonomous)
 
+### Utilities
+
+General-purpose utility skills for Claude Code development.
+
+**Skills included**:
+
+- **[Load Claude Code Docs](./plugins/utilities/skills/load-claude-docs/README.md)** - Fetches the current Claude Code plugin, subagent, and skill docs in parallel and produces a structured API reference in context
+
 ## Installation
 
 ### Using Claude Code
@@ -96,7 +104,7 @@ Once installed, Claude will automatically use these skills when relevant. No man
 ## Marketplace Metadata
 
 - **Name**: `jacks-agent-plugins`
-- **Version**: `1.1.0`
+- **Version**: `1.2.0`
 - **Owner**: John C Burns
 - **License**: MIT
 
@@ -105,6 +113,7 @@ Once installed, Claude will automatically use these skills when relevant. No man
 1. **project-planning** - Project planning and management skills (3 skills)
 2. **engineering** - Software engineering skills (2 skills)
 3. **dev-workflow** - End-to-end development workflow (4 skills, 4 agents)
+4. **utilities** - General-purpose utility skills (1 skill)
 
 ## Resources
 

--- a/plugins/utilities/skills/load-claude-docs/README.md
+++ b/plugins/utilities/skills/load-claude-docs/README.md
@@ -1,0 +1,37 @@
+# Load Claude Code Docs
+
+Fetches the current Claude Code documentation for plugins, subagents, and skills, then produces a structured reference in context — ready to use when authoring new plugin components.
+
+## When to Use
+
+Invoke this skill before:
+- Creating a new plugin, agent, or skill
+- Editing `plugin.json` and needing to verify schema fields
+- Authoring subagent frontmatter and needing to check valid values
+- Authoring a skill and needing to verify `$ARGUMENTS`, `context: fork`, or `allowed-tools` syntax
+
+## Invocation
+
+```
+/utilities:load-claude-docs
+```
+
+No arguments needed.
+
+## What It Does
+
+1. Fetches three Claude Code documentation pages **in parallel**:
+   - `https://code.claude.com/docs/en/plugins`
+   - `https://code.claude.com/docs/en/sub-agents`
+   - `https://code.claude.com/docs/en/skills`
+
+2. Extracts the key technical details from each page:
+   - **Plugins**: directory structure, `plugin.json` schema, component types, `${CLAUDE_PLUGIN_ROOT}`
+   - **Subagents**: frontmatter fields, tool access, models, permission modes, hooks, memory
+   - **Skills**: frontmatter fields, `$ARGUMENTS`, `context: fork`, supporting file patterns
+
+3. Produces a single **Claude Code Reference** block in context with all key info organized by topic
+
+## Output
+
+After running, you'll have a structured reference section in context covering all three APIs — so Claude can use accurate, up-to-date information when helping you build or modify plugin components.

--- a/plugins/utilities/skills/load-claude-docs/SKILL.md
+++ b/plugins/utilities/skills/load-claude-docs/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: load-claude-docs
+description: This skill should be used when the user asks to "load Claude Code docs", "read the Claude Code documentation", "fetch Claude Code plugin docs", or needs up-to-date reference on the Claude Code plugins, subagents, or skills APIs before authoring.
+disable-model-invocation: true
+allowed-tools: WebFetch
+---
+
+# Load Claude Code Docs
+
+Fetches the current Claude Code plugin, subagent, and skill documentation and produces a structured reference in context.
+
+## Instructions
+
+Fetch all three pages **in parallel** using `WebFetch`. Use targeted extraction prompts to pull the technical details needed for authoring.
+
+### Step 1: Fetch All Three Pages (in parallel)
+
+**Plugins page**
+- URL: `https://code.claude.com/docs/en/plugins`
+- Extraction prompt: `Extract all technical details about the plugin directory structure, plugin.json schema (all fields and valid values), component types (commands, agents, skills, hooks), how plugins are installed and distributed, and the ${CLAUDE_PLUGIN_ROOT} variable. List all field names, types, and valid values.`
+
+**Subagents page**
+- URL: `https://code.claude.com/docs/en/sub-agents`
+- Extraction prompt: `Extract all technical details about subagent markdown file structure, every YAML frontmatter field (name, description, tools, model, permission-mode, color, context, etc.) with all valid values, how agents are triggered, tool access configuration, and any hooks or memory patterns. List all field names, types, and valid values.`
+
+**Skills page**
+- URL: `https://code.claude.com/docs/en/skills`
+- Extraction prompt: `Extract all technical details about skill file structure, every YAML frontmatter field (name, description, disable-model-invocation, argument-hint, allowed-tools, context, etc.) with all valid values, how skills are invoked, the $ARGUMENTS variable, context: fork behavior, and supporting file patterns. List all field names, types, and valid values.`
+
+### Step 2: Produce Structured Claude Code Reference
+
+After fetching, produce the following structured reference in your response:
+
+---
+
+## Claude Code Reference
+
+### Plugins — `plugin.json` Schema & Directory Structure
+
+[Key facts from the plugins page: directory layout, all plugin.json fields with types and valid values, component types, `${CLAUDE_PLUGIN_ROOT}`, installation/distribution]
+
+### Subagents — Frontmatter Fields & Triggering
+
+[Key facts from the subagents page: all frontmatter fields with valid values, how agents are triggered, tool access, supported models, permission modes, hooks, memory]
+
+### Skills — Frontmatter Fields & Invocation
+
+[Key facts from the skills page: all frontmatter fields with valid values, invocation patterns, `$ARGUMENTS` syntax, `context: fork` behavior, supporting file patterns]
+
+---
+
+This reference is now in context. Use it when creating or modifying plugins, skills, or agents to ensure correctness against the current API.


### PR DESCRIPTION
## Summary

- Adds a new `utilities` plugin to the marketplace
- Implements `load-claude-docs` skill that fetches Claude Code plugins, subagents, and skills documentation pages in parallel
- Produces a structured API reference in context ready for use when authoring plugin components

## Test plan

- [ ] Run `claude --plugin-dir ./` in repo root
- [ ] Invoke `/utilities:load-claude-docs`
- [ ] Confirm all three doc pages are fetched and a structured Claude Code Reference appears in context
- [ ] Verify key details are present: plugin.json schema, subagent frontmatter fields, skill `$ARGUMENTS` syntax, `context: fork`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)