### PR TITLE
Add pipeline continuity instructions to dev-workflow agents and skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketplace for agent plugins including skills, commands, and tools for software engineering and product development",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/plugins/dev-workflow/agents/code-reviewer.md
+++ b/plugins/dev-workflow/agents/code-reviewer.md
@@ -16,3 +16,9 @@ You are a senior engineer performing a final code review before merge. You are r
 2. Review the PR diff
 3. Evaluate against the criteria in your preloaded `code-review` skill
 4. Produce a structured review report using the output format from the `code-review` skill
+
+## When Done
+
+After delivering the structured review report, always end with this exact line:
+
+> NEXT STEP: Use the retro-agent to conduct a session retrospective and create an improvement issue in johncburns1/plugin-marketplace.

--- a/plugins/dev-workflow/agents/implementation-agent.md
+++ b/plugins/dev-workflow/agents/implementation-agent.md
@@ -59,3 +59,7 @@ After the PR is open, summarize:
 - Which failure modes are covered by tests
 - Any deviations from the plan (flag every one with rationale)
 - Gate results: test count, lint status, coverage %
+
+After delivering the summary, always end with this exact line:
+
+> NEXT STEP: Use the code-reviewer agent to review PR #[PR number] against the plan in GitHub issue #[issue number].

--- a/plugins/dev-workflow/agents/retro-agent.md
+++ b/plugins/dev-workflow/agents/retro-agent.md
@@ -21,3 +21,9 @@ You are conducting a session retrospective to continuously improve the developme
 7. If the source repository differs from `johncburns1/plugin-marketplace` and source-repo findings exist, create a second GitHub issue in the source repository using the Engineering Improvements format from the `retro` skill
 
 Match each finding to a specific skill or agent in the marketplace. Vague feedback ("plan could be better") is not actionable. Specific feedback ("plan-review skill should require explicit error type enumeration before approving") is.
+
+## When Done
+
+After all GitHub issues have been created, always end with this exact line:
+
+> PIPELINE COMPLETE: The dev-workflow session has concluded. All retro findings have been filed.

--- a/plugins/dev-workflow/skills/dev-workflow/SKILL.md
+++ b/plugins/dev-workflow/skills/dev-workflow/SKILL.md
@@ -27,6 +27,18 @@ Follow these steps in order. Do not skip steps. Pause at each human touchpoint m
 
 ---
 
+> **Skill vs. Agent Distinction**: Skills (`engineering-standards`, `plan-review`, `code-review`, `retro`) are reference documents loaded into context — they provide principles and frameworks. Agents (`plan-reviewer`, `implementation-agent`, `code-reviewer`, `retro-agent`) are autonomous sub-processes invoked with "Use the [name] agent." **Using a skill is NOT a substitute for invoking an agent.** If a pipeline step says "invoke the X agent", you must call the Agent tool — loading the X skill is not equivalent and does not complete that step.
+
+---
+
+> **Pipeline state**: Each pipeline step must emit `PIPELINE STEP: [N] of 7 — [step name]` as the first line of its output, so the orchestrator always knows the current position. Example: `PIPELINE STEP: 4 of 7 — Implementation`.
+
+---
+
+> **Routing correction**: If you are mid-session and uncertain which step comes next, re-read this SKILL.md before taking any action. Never assume a previous step was completed — verify it. Never skip a step because the user has provided a partial artifact.
+
+---
+
 Before beginning Step 1, invoke the `engineering-standards` skill:
 
 ```

--- a/plugins/dev-workflow/skills/plan-review/SKILL.md
+++ b/plugins/dev-workflow/skills/plan-review/SKILL.md
@@ -52,6 +52,14 @@ createUser(userData: CreateUserInput): Promise<User>
     - ConflictError if email already exists
 ```
 
+#### Failure Mode Completeness Checklist
+
+Before approving any interface contract, verify:
+
+- [ ] Every status code or error type the interface can return is explicitly named in the plan
+- [ ] Each named error type has a corresponding acceptance criterion that maps to a test case
+- [ ] For changes that replace or remove an existing interface: at least one test verifies the old interface is no longer reachable (route deregistration, removed export, etc.)
+
 ### 3. Simplicity
 
 Evaluate every element of the plan against YAGNI and KISS:


### PR DESCRIPTION
## Summary

- Adds explicit `NEXT STEP` output instructions to `implementation-agent` and `code-reviewer` so each agent tells the orchestrator what to invoke next
- Adds `PIPELINE COMPLETE` output instruction to `retro-agent` to signal session end
- Inserts three orchestrator-guidance callouts into `dev-workflow/SKILL.md` (Skill vs. Agent Distinction, Pipeline State, Routing Correction) grouped after the Routing Rule block
- Adds a Failure Mode Completeness Checklist to `plan-review/SKILL.md` under Interface Contracts to catch missing error types before implementation
- Bumps marketplace version to `1.4.0`

## Test plan

- [ ] Verify `implementation-agent.md` ends with `NEXT STEP: Use the code-reviewer agent...`
- [ ] Verify `code-reviewer.md` has a "When Done" section ending with `NEXT STEP: Use the retro-agent...`
- [ ] Verify `retro-agent.md` has a "When Done" section ending with `PIPELINE COMPLETE: The dev-workflow session has concluded...`
- [ ] Verify `dev-workflow/SKILL.md` contains all three callouts after the Routing Rule block and before `Before beginning Step 1`
- [ ] Verify `plan-review/SKILL.md` Failure Mode Completeness Checklist appears after the `createUser` example and before `### 3. Simplicity`
- [ ] Verify `marketplace.json` reads `"version": "1.4.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)