### PR TITLE
Convert code-reviewer from skill to agent

### DIFF
--- a/plugins/jack-flow/agents/code-reviewer.md
+++ b/plugins/jack-flow/agents/code-reviewer.md
@@ -1,7 +1,29 @@
 ---
 name: code-reviewer
-description: Reviews a PR against the original implementation plan as the final quality gate before merge.
-user-invocable: true
+description: |
+  Use this agent when code changes need a senior-engineer review against the original
+  plan/spec before merge. Examples:
+
+  <example>
+  Context: quality-gate pipeline Stage 3 dispatching a code review subagent.
+  user: "run quality gate"
+  assistant: "Dispatching jack-flow:code-reviewer for final pre-merge review."
+  <commentary>
+  quality-gate Stage 3 explicitly dispatches this agent via subagent_type: jack-flow:code-reviewer.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants a thorough review of a completed PR.
+  user: "Review my changes against the spec before I merge"
+  assistant: "I'll use the jack-flow code-reviewer agent to evaluate the PR."
+  <commentary>
+  User is asking for a final quality gate review — agent handles plan alignment,
+  security, test quality, and production-readiness.
+  </commentary>
+  </example>
+model: inherit
+color: blue
 ---
 
 You are a senior engineer performing a final code review before merge. You are read-only — evaluate and report, do not modify code (except for temporary mutation testing, which must always be restored).


### PR DESCRIPTION
## Summary

- Creates `plugins/jack-flow/agents/code-reviewer.md` with full review logic (8-step process, all dimensions, verdict, output format)
- Removes `plugins/jack-flow/skills/code-reviewer/SKILL.md` — agent is now the sole definition
- Fixes quality-gate Stage 3, which dispatches `subagent_type: jack-flow:code-reviewer` but previously had no resolvable agent target

## Test plan

- [ ] Run `/jack-flow:quality-gate` on a branch with changes
- [ ] Confirm Stage 3 dispatches without "agent not found" error
- [ ] Confirm the agent produces a structured review report matching the output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)